### PR TITLE
Add pairing updates to app. Closes #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install uhid dbus-fast
 Run the following command in a new shell:
 
 ```
-fido2ble/fido2ble.py
+python3 -m fido2ble.fido2ble
 ```
 The above needs some elevated privileges, either through running as root, sudo or by granting python the capabilities needed.
 
@@ -103,12 +103,6 @@ bluetoothctl pair 12:34:56:78:9A:BC
 ```
 
 The OFFPAD will prompt for a pairing code and after that the OFFPAD is paired. We can then turn of the scan that we either sent to the background or have in a different tab. If we backgrounded it, running `fg` will bring it to the foreground before we terminate it with `CTRL+C`
-
-### Notes
-
-It currently only works, if the OFFPAD is previously paired. The code is also set to find OFFPADs as FIDO devices only. If any changes happen to pairings, either new pairing or a removal, the python application must be restarted to updates the UHID devices available.  
-
-
 
 ## Credit
 `/dev/uhid` handling took a lot of notes from https://github.com/BryanJacobs/fido2-hid-bridge but was rewritten significantly.

--- a/fido2ble/CTAPBLEDevice.py
+++ b/fido2ble/CTAPBLEDevice.py
@@ -127,6 +127,7 @@ class CTAPBLEDevice:
             self.fido_control_point = control_point
             self.fido_status = status_characteristic
             self.fido_status_notify_listen = notify_properties
+            self.connected=True
             await self.listen_to_notify()
         else:
             logging.debug(f"Device previously connected: {self.device_id}")
@@ -222,3 +223,22 @@ class CTAPBLEDevice:
         # noinspection PyUnresolvedReferences
         self.device_properties_interface.on_properties_changed(self.properties_changed)
         self.properties_changed_listener_active = True
+
+    def remove_signal_handler(self):
+        """Detach the signal handler to stop listening for property changes."""
+        if not self.properties_changed_listener_active:
+            # If no handler is active, there's nothing to remove
+            return
+
+        if not self.device_properties_interface:
+            logging.warning(f"Device properties interface not initialized for {self.device_id}")
+            return
+
+        logging.debug(f"Removing properties changed signal handler for {self.device_id}")
+        # Assuming the handler can be removed via the same interface object
+        # The library might have an unsubscribe method or equivalent
+        self.device_properties_interface.off_properties_changed(self.properties_changed)
+
+        # Set the listener active flag to False
+        self.properties_changed_listener_active = False
+

--- a/fido2ble/fido2ble.py
+++ b/fido2ble/fido2ble.py
@@ -15,11 +15,66 @@ FIDO_STATUS_UUID = "f1d0fff2-deaa-ecee-b42f-c9ba7ed623bb"
 FIDO_CONTROL_POINT_LENGTH_UUID = "f1d0fff3-deaa-ecee-b42f-c9ba7ed623bb"
 FIDO_SERVICE_REVISION_BITFIELD_UUID = "f1d0fff4-deaa-ecee-b42f-c9ba7ed623bb"
 
+DEVICE_INTERFACE = "org.bluez.Device1"
+PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
+
 logging.basicConfig(
     level=logging.DEBUG,
     format="%(asctime)s.%(msecs)03d %(message)s",
     datefmt='%I:%M:%S')
 logging.getLogger("UHIDDevice").setLevel(logging.ERROR)
+
+fido_devices: dict[str, CTAPBLEDevice]
+hid_devices:  dict[str, CTAPHIDDevice]
+
+async def properties_changed(interface, changed, invalidated):
+    """Handles property changes for Bluetooth devices."""
+    if interface == DEVICE_INTERFACE and "Paired" in changed:
+        await update_fido_devices()
+
+async def interfaces_added(path, interfaces, bus):
+    """Handles new interfaces (e.g., new Bluetooth devices)."""
+    if DEVICE_INTERFACE in interfaces:
+        device1_interface = interfaces[DEVICE_INTERFACE]
+
+        if 'UUIDs' in device1_interface:
+            for uuid in device1_interface['UUIDs'].value:
+                if uuid == FIDO_SERVICE_UUID:
+                    logging.debug(f"Found {path} as new FIDO device")
+                    # Get the specific device object
+                    obj = bus.get_proxy_object('org.bluez', path, await bus.introspect('org.bluez', path))
+                    props = obj.get_interface(PROPERTIES_INTERFACE)
+                    props.on_properties_changed(properties_changed)
+
+async def interfaces_removed(path, interfaces):
+    """Handles removed interfaces (e.g., Bluetooth device lost/disconnected)."""
+    if DEVICE_INTERFACE in interfaces:
+        if path in fido_devices:
+            fido_devices[path].remove_signal_handler()
+            del fido_devices[path]
+            hid_devices[path].device.destroy()
+            del hid_devices[path]
+            logging.debug(f"Device Removed: {path}")
+
+
+async def monitor_bluez():
+    """Connects to BlueZ and listens for device events."""
+
+    bus: MessageBus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+    bluez_introspect = await bus.introspect(
+        "org.bluez", '/'
+    )
+
+    dbus_proxy = bus.get_proxy_object('org.bluez', '/', bluez_introspect)
+    manager = dbus_proxy.get_interface("org.freedesktop.DBus.ObjectManager")
+
+    # Connect signal handlers
+    # noinspection PyUnresolvedReferences
+    manager.on_interfaces_added(lambda path, interfaces: asyncio.create_task(
+        interfaces_added(path, interfaces, bus)))
+    # noinspection PyUnresolvedReferences
+    manager.on_interfaces_removed(interfaces_removed)
+
 
 async def create_device(device_path, dbus_managed_objects, bus) -> CTAPBLEDevice:
     device_proxy = bus.get_proxy_object('org.bluez', device_path, await bus.introspect('org.bluez', device_path))
@@ -47,37 +102,46 @@ async def create_device(device_path, dbus_managed_objects, bus) -> CTAPBLEDevice
 async def find_fido() -> dict[str, CTAPBLEDevice]:
     bus: MessageBus = await MessageBus(bus_type=BusType.SYSTEM).connect()
     bluez_introspect = await bus.introspect(
-         "org.bluez", '/'
+        "org.bluez", '/'
     )
 
     dbus_proxy = bus.get_proxy_object('org.bluez', '/', bluez_introspect)
+    # noinspection PyUnresolvedReferences
     dbus_managed_objects = await dbus_proxy.get_interface("org.freedesktop.DBus.ObjectManager").call_get_managed_objects()
-
-    fido_devices = {}
+    global fido_devices
 
     for device_path in dbus_managed_objects:
+        if device_path in fido_devices:
+            continue
         if 'org.bluez.Device1' in dbus_managed_objects[device_path]:
             if dbus_managed_objects[device_path]['org.bluez.Device1']['Paired'].value:
                 if 'UUIDs' in dbus_managed_objects[device_path]['org.bluez.Device1']:
                     for uuid in dbus_managed_objects[device_path]['org.bluez.Device1']['UUIDs'].value:
                         if uuid == FIDO_SERVICE_UUID:
-                            logging.debug(f"Found {device_path} as FIDO device")
+                            logging.debug(f"Added {device_path} as FIDO device")
                             fido_devices[device_path] = await create_device(device_path, dbus_managed_objects, bus)
                 elif 'ServiceData' in dbus_managed_objects[device_path]['org.bluez.Device1']:
                     if FIDO_SERVICE_UUID in dbus_managed_objects[device_path]['org.bluez.Device1']['ServiceData'].value.keys():
-                        logging.debug(f"Found {device_path} as FIDO device")
+                        logging.debug(f"Added {device_path} as FIDO device")
                         fido_devices[device_path] = await create_device(device_path, dbus_managed_objects, bus)
     return fido_devices
 
 
-async def start_system():
-    fido_devices: dict[str, CTAPBLEDevice] = await find_fido()
-    hid_devices = []
+async def update_fido_devices():
+    global fido_devices, hid_devices
+    fido_devices = await find_fido()
     for fido_device in fido_devices:
-        hid = CTAPHIDDevice(fido_devices[fido_device])
-        # noinspection PyAsyncCall
-        asyncio.create_task(hid.start())
-        hid_devices.append(hid)
+        if fido_device not in hid_devices:
+            hid = CTAPHIDDevice(fido_devices[fido_device])
+            asyncio.create_task(hid.start())
+            hid_devices[fido_device] = hid
+
+async def start_system():
+    global fido_devices, hid_devices
+    fido_devices = {}
+    hid_devices = {}
+    await update_fido_devices()
+    await monitor_bluez()
     await asyncio.Event().wait()
 
 def main():

--- a/fido2ble/fido2ble.py
+++ b/fido2ble/fido2ble.py
@@ -40,7 +40,7 @@ async def interfaces_added(path, interfaces, bus):
         if 'UUIDs' in device1_interface:
             for uuid in device1_interface['UUIDs'].value:
                 if uuid == FIDO_SERVICE_UUID:
-                    logging.debug(f"Found {path} as new FIDO device")
+                    logging.info(f"Found new FIDO device: {path}")
                     # Get the specific device object
                     obj = bus.get_proxy_object('org.bluez', path, await bus.introspect('org.bluez', path))
                     props = obj.get_interface(PROPERTIES_INTERFACE)
@@ -54,7 +54,7 @@ async def interfaces_removed(path, interfaces):
             del fido_devices[path]
             hid_devices[path].device.destroy()
             del hid_devices[path]
-            logging.debug(f"Device Removed: {path}")
+            logging.info(f"Device Removed: {path}")
 
 
 async def monitor_bluez():
@@ -118,11 +118,11 @@ async def find_fido() -> dict[str, CTAPBLEDevice]:
                 if 'UUIDs' in dbus_managed_objects[device_path]['org.bluez.Device1']:
                     for uuid in dbus_managed_objects[device_path]['org.bluez.Device1']['UUIDs'].value:
                         if uuid == FIDO_SERVICE_UUID:
-                            logging.debug(f"Added {device_path} as FIDO device")
+                            logging.info(f"Added {device_path} as FIDO device")
                             fido_devices[device_path] = await create_device(device_path, dbus_managed_objects, bus)
                 elif 'ServiceData' in dbus_managed_objects[device_path]['org.bluez.Device1']:
                     if FIDO_SERVICE_UUID in dbus_managed_objects[device_path]['org.bluez.Device1']['ServiceData'].value.keys():
-                        logging.debug(f"Added {device_path} as FIDO device")
+                        logging.info(f"Added {device_path} as FIDO device")
                         fido_devices[device_path] = await create_device(device_path, dbus_managed_objects, bus)
     return fido_devices
 


### PR DESCRIPTION
Adds a monitor that tracks the interfaces added and removed to the bluez dbus objectmanager.
Filter the added interfaces for fido devices, and setup another listener that listens to changes to the "Paired" property. The listener callback then updates the list of devices.

We make the fido_devices and hid_devices global, so the callbacks can access them without passing arguments everywhere.

The interfaces removed callback checks if the removed interface belonged to a device we had stored, and then delete it from our lists.

The new update_fido_devices method checks the devices we get from the objectmanager against those stored in the app to avoid duplicates

Finally, we set the self.connected flag to true at the end of the connect method. At this point we have gathered all characteristics from the device, so we know we are connected.
We need to set this here, because our 'Connected' listener only listens to changes in the property. However, after we pair we are already connected, so this won't happen until we disconnect. Without explicitly setting the flag here, we need to disconnect after pairing to use the device.